### PR TITLE
Update rack-facebook-signed-request.gemspec

### DIFF
--- a/rack-facebook-signed-request.gemspec
+++ b/rack-facebook-signed-request.gemspec
@@ -47,7 +47,6 @@ Gem::Specification.new do |s|
       s.add_runtime_dependency(%q<rack>, [">= 0"])
       s.add_development_dependency(%q<jeweler>, [">= 0"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
-      s.add_runtime_dependency(%q<rack>, [">= 0"])
       s.add_runtime_dependency(%q<yajl-ruby>, [">= 0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])


### PR DESCRIPTION
- Remove duplicate line that causes new bundler to fail